### PR TITLE
Update delay API to fulfill Mbed v6.x

### DIFF
--- a/mbed_bme680.cpp
+++ b/mbed_bme680.cpp
@@ -333,7 +333,7 @@ int8_t BME680::i2c_write(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, ui
 
 void BME680::delay_msec(uint32_t ms) {
     log(" * wait %d ms ... \r\n", ms);
-    wait_ms(ms);
+    wait_us(ms*1000);
 }
 
 void BME680::log(const char *format, ...) {


### PR DESCRIPTION
This PR is to implement `delay_msec()` function by `wait_us()` for Mbed OS v6.x.